### PR TITLE
fix navigation in second_scene for Godot 3.5

### DIFF
--- a/device/globals/terrain.gd
+++ b/device/globals/terrain.gd
@@ -7,6 +7,8 @@ export var bitmaps_scale = Vector2(1,1) setget set_bm_scale,get_bm_scale
 export(int, "None", "Scales", "Lightmap") var debug_mode = 1 setget debug_mode_updated
 export var scale_min = 0.3
 export var scale_max = 1.0
+export var x_offset = 0
+export var y_offset = 0
 var texture
 var img_area
 var _texture_dirty = false
@@ -37,7 +39,6 @@ func get_bm_scale():
 func _update_texture():
 	if _texture_dirty:
 		return
-
 	_texture_dirty = true
 	call_deferred("_do_update_texture")
 
@@ -55,12 +56,12 @@ func _do_update_texture():
 	texture = ImageTexture.new()
 	if debug_mode == 1:
 		if scales != null:
-			#texture.create_from_image(scales)
-			texture = scales
+			texture.create_from_image(scales)
+#			texture = scales
 	else:
 		if lightmap != null:
-			#texture.create_from_image(lightmap)
-			texture = lightmap
+			texture.create_from_image(lightmap)
+#			texture = lightmap
 
 	update()
 
@@ -70,7 +71,7 @@ func debug_mode_updated(p_mode):
 
 func make_local(pos):
 	pos = pos - get_position()
-	pos = pos * 1.0 / get_scale()
+	pos = pos / get_scale()
 	if self is Navigation2D:
 		pos = get_closest_point(pos)
 	return pos
@@ -127,10 +128,10 @@ func get_light(pos):
 func get_pixel(pos, p_image):
 
 	pos = make_local(pos)
-	pos = pos * 1.0 / bitmaps_scale
+	pos = (pos - Vector2(x_offset, y_offset)) / bitmaps_scale
 
 	if pos.x + 1 >= p_image.get_width() || pos.y + 1 >= p_image.get_height() || pos.x < 0 || pos.y < 0:
-		return Color()
+		return Color(1, 1, 1, 1)
 
 
 	p_image.lock()
@@ -178,13 +179,9 @@ func _draw():
 		return
 	if debug_mode == 0:
 		return
-	#if !get_tree().is_editor_hint():
-	#	printt("*********no editor hint")
-	#	return
-	var scale = bitmaps_scale
 
 	var src = Rect2(0, 0, texture.get_width(), texture.get_height())
-	var dst = Rect2(0, 0, texture.get_width() * scale.x, texture.get_height() * scale.y)
+	var dst = Rect2(x_offset, y_offset, texture.get_width() * bitmaps_scale.x, texture.get_height() * bitmaps_scale.y)
 
 	draw_texture_rect_region(texture, dst, src)
 	#draw_texture(texture, Vector2(0, 0))

--- a/device/scenes/second_scene/scene.tscn
+++ b/device/scenes/second_scene/scene.tscn
@@ -52,17 +52,16 @@ texture = ExtResource( 15 )
 script = ExtResource( 10 )
 
 [node name="terrain" type="Navigation2D" parent="."]
-position = Vector2( 0, 440 )
 script = ExtResource( 11 )
 scales = SubResource( 2 )
 lightmap = SubResource( 3 )
 bitmaps_scale = Vector2( 4, 4 )
 debug_mode = 0
-scale_min = 0.05
+scale_min = 0.2
 scale_max = 0.75
+y_offset = 440
 
 [node name="NavigationPolygonInstance" type="NavigationPolygonInstance" parent="terrain"]
-position = Vector2( 0, -442 )
 navpoly = SubResource( 1 )
 
 [node name="middle_ground_1" type="Sprite" parent="."]
@@ -105,22 +104,16 @@ __meta__ = {
 position = Vector2( 1039.61, 841.002 )
 z_index = 841
 tooltip = "A shiny bamboo"
-placeholders = {
-}
 
 [node name="good_bamboo_2" parent="." instance=ExtResource( 18 )]
 position = Vector2( 1643.11, 860.781 )
 z_index = 860
 tooltip = "A well hiden bamboo"
-placeholders = {
-}
 
 [node name="good_bamboo_3" parent="." instance=ExtResource( 16 )]
 position = Vector2( 472.343, 663.334 )
 z_index = 663
 tooltip = "A delicious bamboo"
-placeholders = {
-}
 
 [node name="bamboo_god_2" parent="." instance=ExtResource( 12 )]
 visible = false
@@ -128,17 +121,13 @@ position = Vector2( 984.846, 590.185 )
 z_index = 590
 tooltip = "The Great Panda himself!"
 active = false
-placeholders = {
-}
 
 [node name="player" parent="." instance=ExtResource( 7 )]
-position = Vector2( 742.707, 850.866 )
-scale = Vector2( 0.454718, 0.454718 )
-z_index = 850
+position = Vector2( 733, 816 )
+scale = Vector2( 0.05, 0.05 )
+z_index = 817
 speed = 1000
 telekinetic = true
-placeholders = {
-}
 
 [node name="foreground left" type="Sprite" parent="."]
 position = Vector2( 236.924, 663.079 )
@@ -160,7 +149,5 @@ __meta__ = {
 position = Vector2( 1752.96, 675.222 )
 z_index = 3000
 tooltip = "A chameleon"
-placeholders = {
-}
 
 [node name="game" parent="." instance=ExtResource( 14 )]


### PR DESCRIPTION
fix navigation in second_scene, add x_offset and y_offset on the terrain to set the offset of Scales and Lightmaps maps relative to the background